### PR TITLE
feat: add push option with go-git

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Viktor A. Rozenko Voitenko <sharp.vik@gmail.com>
 pkgname=sema
-pkgver=2.0.0
-pkgrel=15
+pkgver=2.0.1
+pkgrel=16
 pkgdesc="Semantic commit tool"
 arch=(x86_64)
 url="https://github.com/sharpvik/sema"

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -11,6 +11,7 @@ import (
 
 type (
 	Agent struct {
+		repo        *git.Repository
 		Config      *Config
 		workTree    *git.Worktree
 		commitTitle string
@@ -38,11 +39,12 @@ func New(config *Config) *Agent {
 }
 
 func (a *Agent) Init() (err error) {
-	repo, err := git.PlainOpen(".")
+	a.repo, err = git.PlainOpen(".")
 	if err != nil {
 		return
 	}
-	a.workTree, err = repo.Worktree()
+
+	a.workTree, err = a.repo.Worktree()
 	return
 }
 
@@ -72,12 +74,10 @@ func (a *Agent) Commit() (err error) {
 	}
 }
 
-func (a *Agent) Push() (err error) {
-	args := []string{"push"}
-	if a.Config.Push.Force {
-		args = append(args, "-f")
-	}
-	return try(exec.Command("git", args...))
+func (a *Agent) Push() error {
+	return a.repo.Push(&git.PushOptions{
+		Force: a.Config.Push.Force,
+	})
 }
 
 func (a *Agent) longCommit() (err error) {

--- a/agent/util.go
+++ b/agent/util.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"os/exec"
 
-	. "github.com/logrusorgru/aurora"
+	"github.com/logrusorgru/aurora"
 	"github.com/manifoldco/promptui"
 	"github.com/sharpvik/sema/labels"
 )
@@ -35,7 +35,7 @@ func synopsis() (message string) {
 }
 
 func display(message string) {
-	fmt.Printf("Commit: %v\n\n", Green(message))
+	fmt.Printf("Commit: %v\n\n", aurora.Green(message))
 }
 
 func AbortIfError(err error) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/sharpvik/sema
 go 1.16
 
 require (
-	github.com/go-git/go-git/v5 v5.4.2 // indirect
+	github.com/go-git/go-git/v5 v5.4.2
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/magefile/mage v1.13.0
 	github.com/manifoldco/promptui v0.8.0


### PR DESCRIPTION
## Context
The old `--push/-p` version still used `git` binary.

## Solution
Store the initialized `*git.Repository` in `Agent` structure.
Use `*git.Repository.Push` with `force` option as `*git.PushOptions`.

## Issue
closes #16